### PR TITLE
Fix navbar relative path issue

### DIFF
--- a/bulma/partials/navbar.html
+++ b/bulma/partials/navbar.html
@@ -15,19 +15,19 @@
       {% for nav_item in nav %}
         {% if nav_item.children %}
           <div class="navbar-item has-dropdown is-hoverable">
-              <a class="navbar-link" href="{{ nav_item.url }}">
+              <a class="navbar-link" href="{{ nav_item.url | url}}">
                 {{ nav_item.title }}
               </a>
               <div class="navbar-dropdown is-boxed">
                 {% for nav_item in nav_item.children %}
-                  <a class="navbar-item" href="{{ nav_item.url }}">
+                  <a class="navbar-item" href="{{ nav_item.url | url}}">
                     {{ nav_item.title }}
                   </a>
                 {% endfor %}
               </div>
           </div>
         {% else %}
-          <a class="navbar-item" href="{{ nav_item.url }}">
+          <a class="navbar-item" href="{{ nav_item.url | url}}">
             {{ nav_item.title }}
           </a>
         {% endif %}


### PR DESCRIPTION
Without this, url displayed in the navbar are **relative to the current url** (which isn't the way it works). This **url template filter** concatenates navbar urls with the `site_url` declared in `mkdocs.yaml`, leading to absolute paths: 

Cf [documentation on Mkdocs custom template](https://www.mkdocs.org/user-guide/custom-themes/). 

(Good job by the way, my current web site is based on this team)